### PR TITLE
Fix java version check

### DIFF
--- a/src/main/java/com/helger/phase4/peppolstandalone/controller/PeppolSenderController.java
+++ b/src/main/java/com/helger/phase4/peppolstandalone/controller/PeppolSenderController.java
@@ -99,7 +99,7 @@ public class PeppolSenderController
       final SMPClientReadOnly aSMPClient = new SMPClientReadOnly (Phase4PeppolSender.URL_PROVIDER,
                                                                   aReceiverID,
                                                                   aSmlInfo);
-      if (EJavaVersion.JDK_17.isNewerOrEqualsThan (EJavaVersion.getCurrentVersion ()))
+      if (EJavaVersion.getCurrentVersion ().isNewerOrEqualsThan (EJavaVersion.JDK_17))
       {
         // Work around the disabled SHA-1 in XMLDsig issue
         aSMPClient.setSecureValidation (false);


### PR DESCRIPTION
The sha1 signature deprecation has been applied in java version 17 and higher, while the if statement checked for java version 17 and lower.