### PR TITLE
fixed log output still using a fixed text for the type of message

### DIFF
--- a/src/main/java/com/helger/phase4/peppolstandalone/controller/PeppolSenderController.java
+++ b/src/main/java/com/helger/phase4/peppolstandalone/controller/PeppolSenderController.java
@@ -148,7 +148,9 @@ public class PeppolSenderController
     final String sDocTypeID = aData.getDocumentTypeAsIdentifier ().getURIEncoded ();
     final String sProcessID = aData.getProcessAsIdentifier ().getURIEncoded ();
     final String sCountryCodeC1 = aData.getCountryC1 ();
-    LOGGER.info ("Trying to send Peppol Test SBDH message from '" +
+    LOGGER.info ("Trying to send Peppol " +
+                 eStage.name() +
+                 " SBDH message from '" +
                  sSenderID +
                  "' to '" +
                  sReceiverID +


### PR DESCRIPTION
One of the log messages still uses a fixed text for the type of the message being sent. This fix changes that